### PR TITLE
fix: remove duplicate Header/Footer from home layout

### DIFF
--- a/app/home/layout.tsx
+++ b/app/home/layout.tsx
@@ -1,30 +1,3 @@
-'use client'
-
-import type { ReactNode } from 'react'
-import { ThemeProvider } from 'next-themes'
-import { Header } from '../header'
-import { Footer } from '../footer'
-import '../globals.css'
-
-export default function HomeLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en" suppressHydrationWarning>
-      <body className="bg-white tracking-tight antialiased dark:bg-zinc-950">
-        <ThemeProvider
-          enableSystem={true}
-          attribute="class"
-          storageKey="theme"
-          defaultTheme="system"
-        >
-          <div className="flex min-h-screen w-full flex-col">
-            <div className="mx-auto w-full max-w-screen-sm flex-1 px-4 py-8 sm:px-6 md:px-8">
-              <Header />
-              {children}
-              <Footer />
-            </div>
-          </div>
-        </ThemeProvider>
-      </body>
-    </html>
-  )
+export default function HomeLayout({ children }: { children: React.ReactNode }) {
+  return children
 }


### PR DESCRIPTION
Close #23

## Summary

/homeページでリロード時にHeaderとFooterが重複表示される問題を修正。

root layoutですでにHeader/Footerがレンダリングされているため、home layoutでの重複レンダリングを削除。

Generated with [Claude Code](https://claude.ai/code)