### PR TITLE
fix: make image responsive on mobile by adjusting height breakpoint

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
 
       {/* Campaign Banner with Image */}
       <div className="relative w-full">
-        <div className="relative h-80 w-full overflow-hidden">
+        <div className="relative h-48 md:h-80 w-full overflow-hidden">
           <Image
             src="/IMG_7010.png"
             alt="Campaign"


### PR DESCRIPTION
Closes #30

- Changed fixed height (h-80) to responsive height (h-48 on mobile, md:h-80 on desktop)
- Ensures image displays fully on mobile without being cut off

Generated with [Claude Code](https://claude.ai/code)